### PR TITLE
New option commonYAxis

### DIFF
--- a/www/edit.html
+++ b/www/edit.html
@@ -74,7 +74,12 @@
                         <table style="table-layout: fixed;" id="idslist" border="0" cellspacing="0" cellpadding="0"></table>
                     </td>
                 </tr>
-
+               <tr>
+                 <td colspan="7">
+					<span class="translate">Common Y Axis:</span><input type="checkbox" class="value" id="commonYAxis"/>
+                 </td>
+               </tr>
+				
                 <!--<tr>-->
                 <!--<td class="translate label">same Day:</td>-->
                 <!--<td><input type="checkbox" id="sameDay" class="value"></td>-->
@@ -369,7 +374,8 @@
                     unit:       '',
                     name:       ''
                 }
-            ]
+            ],
+		commonYAxis: false	
         }
     };
 

--- a/www/index.html
+++ b/www/index.html
@@ -958,8 +958,17 @@
             settings.yaxes.push(yaxi);
             settings.xaxes.push(xaxi);
 //            settings.yaxis["y"+(ii +1)] = axi
-            series[ii].yaxis = ii + 1;
-            series[ii].xaxis = ii + 1;
+
+// Support for commonYAxis
+            if (config.commonYAxis === 'true' || config.commonYAxis === true)
+			  {
+			  series[ii].yaxis = 1;
+			  }
+             else  
+              {
+			  series[ii].yaxis = ii + 1;
+              }			  
+			series[ii].xaxis = ii + 1;
         }
 
         if (config.smoothing) {

--- a/www/js/words.js
+++ b/www/js/words.js
@@ -461,5 +461,6 @@ systemDictionary = {
     "Auto-update:":         {"en": "Auto-update:",          "de": "Auto-update:",           "ru": "Обновлять сразу:"},
     "Use comma:":           {"en": "Use comma:",            "de": "Benutze Komma:",         "ru": "Запятая-разделитель:"},
     "Custom background:":   {"en": "Custom background:",    "de": "Anwender-Hintergrund:",  "ru": "Пользовательский фон:"},
-    "Instance":             {"en": "Instance",              "de": "Instanz",                "ru": "Драйвер"}
+    "Instance":             {"en": "Instance",              "de": "Instanz",                "ru": "Драйвер"},
+	"Common Y Axis:":        {"en": "Common Y Axis:",         "de": "Gemeinsame Y-Achse:",     "ru": "Common Y Axis:"}
 };


### PR DESCRIPTION
Wenn diese Option aktiviert ist, werden alle Datenreihen auf die Y-Achse 1 gesetzt. Dies ist dann sinnvoll, wenn man mehrere Datenreihen mit der gleichen Einheit wie z.B. °C hat und die Achse von Flot anhand der Werte für alle Reihen gleich gesetzt werden soll.
