### PR TITLE
fix #34

### DIFF
--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -99,7 +99,7 @@ function CustomChart(options, config, seriesData, markLines, ticks) {
                 var data = that.chart.getData();
 
                 for (var d = markingsOffset; d < data.length; d++) {
-                    if (!that.config.l[d-markingsOffset] || that.config.l[d-markingsOffset].chartType !== 'bar') continue;
+                    if (!that.config.l[d - markingsOffset] || that.config.l[d - markingsOffset].chartType !== 'bar') continue;
 
                     $.each(data[d].data, function (i, el) {
                         if (el[1] === null) return;
@@ -119,7 +119,7 @@ function CustomChart(options, config, seriesData, markLines, ticks) {
                             o = that.chart.pointOffset({x: el[0], y: el[1] / 2});
                         }
 
-                        $('<div class="data-point-label"><div style="width: 100%; margin-left: -50%;">' + _yFormatter(el[1], d-markingsOffset) + '</div></div>').css({
+                        $('<div class="data-point-label"><div style="width: 100%; margin-left: -50%;">' + _yFormatter(el[1], d - markingsOffset) + '</div></div>').css({
                             position: 'absolute',
                             left: o.left,
                             top: o.top

--- a/src/js/chart.js
+++ b/src/js/chart.js
@@ -98,8 +98,8 @@ function CustomChart(options, config, seriesData, markLines, ticks) {
             setTimeout(function () {
                 var data = that.chart.getData();
 
-                for (var d = 0; d < data.length; d++) {
-                    if (!that.config.l[d] || that.config.l[d].chartType !== 'bar') continue;
+                for (var d = markingsOffset; d < data.length; d++) {
+                    if (!that.config.l[d-markingsOffset] || that.config.l[d-markingsOffset].chartType !== 'bar') continue;
 
                     $.each(data[d].data, function (i, el) {
                         if (el[1] === null) return;
@@ -119,7 +119,7 @@ function CustomChart(options, config, seriesData, markLines, ticks) {
                             o = that.chart.pointOffset({x: el[0], y: el[1] / 2});
                         }
 
-                        $('<div class="data-point-label"><div style="width: 100%; margin-left: -50%;">' + _yFormatter(el[1], d) + '</div></div>').css({
+                        $('<div class="data-point-label"><div style="width: 100%; margin-left: -50%;">' + _yFormatter(el[1], d-markingsOffset) + '</div></div>').css({
                             position: 'absolute',
                             left: o.left,
                             top: o.top


### PR DESCRIPTION
In case of marking lines series data and config.l are not in synch because series data uses a marking-offset for marking line data which is stored at the beginning of the series data. A corresponding config.l does not exist at this position. Using the global marking offset for accessing the correct series data in case of bar labels solves the issue.