### PR TITLE
Fix issue of web adapter giving port-only url of websocket interface

### DIFF
--- a/src/js/edit.js
+++ b/src/js/edit.js
@@ -1498,7 +1498,7 @@ $(document).ready(function () {
         console.log('Init connection...');
 	// Correct "port only" url given from web adapter:
 	var correctSocketUrl = socketUrl;
-	if (correctSocketUrl[0] === ':') {
+	if (correctSocketUrl && correctSocketUrl[0] === ':') {
 	    correctSocketUrl = location.protocol + '//' + location.hostname + socketUrl;
 	}
         // Read instances

--- a/src/js/edit.js
+++ b/src/js/edit.js
@@ -1496,6 +1496,11 @@ $(document).ready(function () {
 
     function initSocket() {
         console.log('Init connection...');
+	// Correct "port only" url given from web adapter:
+	var correctSocketUrl = socketUrl;
+	if (correctSocketUrl[0] === ':') {
+	    correctSocketUrl = location.protocol + '//' + location.hostname + socketUrl;
+	}
         // Read instances
         socket = io.connect(socketUrl, {
             query: {


### PR DESCRIPTION
As detailed in #122 this fixes the bug of not normalizing the port-only url given by the web adapter for websocket connections. The same fix is already contained in another module, so it should be alright.

Unfortunately I am missing the tools to minify the JS code, so only the original edit.js version contains the fix - not the one in the www folder.